### PR TITLE
Small performance improvement for DriverFactory

### DIFF
--- a/dotnet/test/common/Environment/DriverFactory.cs
+++ b/dotnet/test/common/Environment/DriverFactory.cs
@@ -46,7 +46,7 @@ namespace OpenQA.Selenium.Environment
                 browser = Browser.Chrome;
                 options = GetDriverOptions<ChromeOptions>(driverType, driverOptions);
             }
-            if (typeof(EdgeDriver).IsAssignableFrom(driverType))
+            else if (typeof(EdgeDriver).IsAssignableFrom(driverType))
             {
                 browser = Browser.Edge;
                 options = GetDriverOptions<EdgeOptions>(driverType, driverOptions);


### PR DESCRIPTION
### Description
I noticed in https://github.com/SeleniumHQ/selenium/commit/962a34bfcfd6b5368f9f5df9e5e188b75771f891 that an `if`-statement was used, while probably an `else-if` should have been used, to skip all other conditions when the Chrome driver is used.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
